### PR TITLE
Multiple code improvements - squid:S1213, squid:S134, squid:S1066, squid:S2130

### DIFF
--- a/src/main/java/jenkins/plugins/asqatasun/AsqatasunInstallation.java
+++ b/src/main/java/jenkins/plugins/asqatasun/AsqatasunInstallation.java
@@ -32,10 +32,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class AsqatasunInstallation {
 
-    public static final AsqatasunInstallation get() {
-        return Jenkins.getInstance().getDescriptorByType(AsqatasunRunnerBuilder.DescriptorImpl.class).getInstallation();
-    }
-
     private final String webappUrl;
 
     private final String databaseHost;
@@ -62,6 +58,10 @@ public class AsqatasunInstallation {
         this.databaseLogin = databaseLogin;
         setDatabasePassword(databasePassword);
         this.asqatasunLogin = asqatasunLogin;
+    }
+
+    public static final AsqatasunInstallation get() {
+        return Jenkins.getInstance().getDescriptorByType(AsqatasunRunnerBuilder.DescriptorImpl.class).getInstallation();
     }
 
     public String getWebappUrl() {

--- a/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunnerBuilder.java
+++ b/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunnerBuilder.java
@@ -332,11 +332,9 @@ public class AsqatasunRunnerBuilder extends Builder {
      */
     public static File createTempFile(File contextDir, String fileName, String fileContent) throws IOException {
         File contextDirTemp = new File (contextDir.getAbsolutePath()+"/tmp");
-        if (!contextDirTemp.exists()) {
-            if (contextDirTemp.mkdir()) {
-                contextDirTemp.setExecutable(true);
-                contextDirTemp.setWritable(true);
-            }
+        if (!contextDirTemp.exists() && contextDirTemp.mkdir()) {
+            contextDirTemp.setExecutable(true);
+            contextDirTemp.setWritable(true);
         }
         File tempFile = new File(contextDirTemp.getAbsolutePath()+"/"+fileName);
         FileUtils.writeStringToFile(tempFile, fileContent);
@@ -527,7 +525,7 @@ public class AsqatasunRunnerBuilder extends Builder {
                 return FormValidation.ok();
             }
             try {
-                int mark = Integer.valueOf(value);
+                int mark = Integer.parseInt(value);
                 if (mark > 65535) {
                   return FormValidation.error("Please fill-in a valid maximal number of failed occurences threshold");
                 }

--- a/src/main/java/jenkins/plugins/asqatasun/ProjectAsqatasunAction.java
+++ b/src/main/java/jenkins/plugins/asqatasun/ProjectAsqatasunAction.java
@@ -61,21 +61,26 @@ public class ProjectAsqatasunAction implements ProminentProjectAction {
     public String getUrlName() {
         String webappUrl = Jenkins.getInstance().getDescriptorByType(AsqatasunRunnerBuilder.DescriptorImpl.class).getInstallation().getWebappUrl();
         if (project.getLastBuild() != null) {
-            try {
-                for (Object obj : FileUtils.readLines(project.getLastBuild().getLogFile())) {
-                    String line = (String)obj;
-                    if (StringUtils.startsWith(line, "Audit Id")) {
-                        return buildAuditResultUrl(line, webappUrl);
-                    }
-                }
-            }  catch (IOException ex) {
-                Logger.getLogger(ProjectAsqatasunAction.class.getName()).log(Level.SEVERE, null, ex);
-            }
+            return buildAuditResultUrl(webappUrl);
         }
         return webappUrl;
     }
 
-    private String buildAuditResultUrl(String line, String webappUrl) {
+    private String buildAuditResultUrl(String webappUrl) {
+        try {
+            for (Object obj : FileUtils.readLines(project.getLastBuild().getLogFile())) {
+                String line = (String)obj;
+                if (StringUtils.startsWith(line, "Audit Id")) {
+                    return doBuildAuditResultUrl(line, webappUrl);
+                }
+            }
+        }  catch (IOException ex) {
+            Logger.getLogger(ProjectAsqatasunAction.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return webappUrl;
+    }
+
+    private String doBuildAuditResultUrl(String line, String webappUrl) {
         String auditId = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
         if (StringUtils.endsWith(webappUrl, "/")) {
             return webappUrl+URL_PREFIX_RESULT+auditId;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S2130
Please let me know if you have any questions.
George Kankava
