### PR TITLE
Multiple code improvements - squid:ClassVariableVisibilityCheck, squid:S1192, squid:MethodCyclomaticComplexity

### DIFF
--- a/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunner.java
+++ b/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunner.java
@@ -47,14 +47,14 @@ public class AsqatasunRunner {
     private final BuildListener listener;
     private final boolean isDebug;
     
-    public String auditId;
-    public String mark;
-    public String nbPassed;
-    public String nbFailed;
-    public String nbFailedOccurences;
-    public String nbNmi;
-    public String nbNa;
-    public String nbNt;
+    private String auditId;
+    private String mark;
+    private String nbPassed;
+    private String nbFailed;
+    private String nbFailedOccurences;
+    private String nbNmi;
+    private String nbNa;
+    private String nbNt;
     
     public AsqatasunRunner(
             String tgScriptName,
@@ -151,41 +151,23 @@ public class AsqatasunRunner {
                     isFirstMark = false;
                 }
             } else if (StringUtils.startsWith(line, "Nb Passed")) {
-                ps.println(line); 
-                if (isFirstNbPassed) {
-                  nbPassed = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                    isFirstNbPassed = false;
-                }
+                nbPassed = getNbStatus(ps, isFirstNbPassed, line);
+                isFirstNbPassed = false;
             } else if (StringUtils.startsWith(line, "Nb Failed test")) {
-                ps.println(line);
-                if (isFirstNbFailed) {
-                   nbFailed = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                   isFirstNbFailed = false;
-                }
+                nbFailed = getNbStatus(ps, isFirstNbFailed, line);
+                isFirstNbFailed = false;
             } else if (StringUtils.startsWith(line, "Nb Failed occurences")) {
-                ps.println(line);
-                if (isFirstNbFailedOccurences) {
-                    nbFailedOccurences = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                    isFirstNbFailedOccurences = false;
-                }
+                nbFailedOccurences = getNbStatus(ps, isFirstNbFailedOccurences, line);
+                isFirstNbFailedOccurences = false;
             } else if (StringUtils.startsWith(line, "Nb Pre-qualified")) {
-                ps.println(line);
-                if (isFirstNbNmi) {
-                    nbNmi = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                    isFirstNbNmi= false;
-                }
+                nbNmi = getNbStatus(ps, isFirstNbNmi, line);
+                isFirstNbNmi = false;
             } else if (StringUtils.startsWith(line, "Nb Not Applicable")) {
-                ps.println(line);
-                if (isFirstNbNa) {
-                    nbNa = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                    isFirstNbNa = false;
-                }
+                nbNa = getNbStatus(ps, isFirstNbNa, line);
+                isFirstNbNa = false;
             } else if (StringUtils.startsWith(line, "Nb Not Tested")) {
-                ps.println(line);
-                if (isFirstNbNt) {
-                    nbNt = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
-                    isFirstNbNt = false;
-                }
+                nbNt = getNbStatus(ps, isFirstNbNt, line);
+                isFirstNbNt = false;
             } else if (StringUtils.startsWith(line, "Audit Id")) {
                 ps.println(line);
                 auditId = StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
@@ -194,8 +176,47 @@ public class AsqatasunRunner {
         ps.println("");
     }
 
+    private String getNbStatus(PrintStream ps, boolean isFirstNb, String line) {
+        ps.println(line);
+        if (isFirstNb) {
+           return StringUtils.substring(line, StringUtils.indexOf(line, ":")+1).trim();
+        }
+        return null;
+    }
+
     public String outputAsqatasunResults() {
         return toString();
     }
 
+    public String getAuditId() {
+        return auditId;
+    }
+
+    public String getMark() {
+        return mark;
+    }
+
+    public String getNbPassed() {
+        return nbPassed;
+    }
+
+    public String getNbFailed() {
+        return nbFailed;
+    }
+
+    public String getNbFailedOccurences() {
+        return nbFailedOccurences;
+    }
+
+    public String getNbNmi() {
+        return nbNmi;
+    }
+
+    public String getNbNa() {
+        return nbNa;
+    }
+
+    public String getNbNt() {
+        return nbNt;
+    }
 }

--- a/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunnerBuilder.java
+++ b/src/main/java/jenkins/plugins/asqatasun/AsqatasunRunnerBuilder.java
@@ -76,7 +76,8 @@ public class AsqatasunRunnerBuilder extends Builder {
     private static final String INSERT_ACT_SCRIPT_NAME = "insert-act.sh";
     private static final String TMP_FOLDER_NAME = "tmp/";
     private static final String DEFAULT_XMX_VALUE = "256";
-    
+    public static final String QUOTES = "'\"'\"'";
+
     private final String scenario;
     private final String scenarioName;
     private final String refAndLevel;
@@ -250,10 +251,10 @@ public class AsqatasunRunnerBuilder extends Builder {
         ProcessBuilder pb = new ProcessBuilder(
                 TMP_FOLDER_NAME+INSERT_ACT_SCRIPT_NAME,
                 AsqatasunInstallation.get().getAsqatasunLogin(),
-                projectName.replaceAll("'", "'\"'\"'"),
-                scenarioName.replaceAll("'", "'\"'\"'"),
-                AsqatasunRunnerBuilder.forceVersion1ToScenario(scenario.replaceAll("'", "'\"'\"'")),
-                asqatasunRunner.auditId);
+                projectName.replaceAll("'", QUOTES),
+                scenarioName.replaceAll("'", QUOTES),
+                AsqatasunRunnerBuilder.forceVersion1ToScenario(scenario.replaceAll("'", QUOTES)),
+                asqatasunRunner.getAuditId());
 
         pb.directory(contextDir);
         pb.redirectErrorStream(true);
@@ -278,13 +279,13 @@ public class AsqatasunRunnerBuilder extends Builder {
         
         File workspacedir = new File(workspace.toURI());
         
-        writeValueToFile(asqatasunRunner.mark, "mark", workspacedir);
-        writeValueToFile(asqatasunRunner.nbPassed, "passed", workspacedir);
-        writeValueToFile(asqatasunRunner.nbFailed, "failed", workspacedir);
-        writeValueToFile(asqatasunRunner.nbFailedOccurences, "failedOccurences", workspacedir);
-        writeValueToFile(asqatasunRunner.nbNmi, "nmi", workspacedir);
-        writeValueToFile(asqatasunRunner.nbNa, "na", workspacedir);
-        writeValueToFile(asqatasunRunner.nbNt, "nt", workspacedir);
+        writeValueToFile(asqatasunRunner.getMark(), "mark", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbPassed(), "passed", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbFailed(), "failed", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbFailedOccurences(), "failedOccurences", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbNmi(), "nmi", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbNa(), "na", workspacedir);
+        writeValueToFile(asqatasunRunner.getNbNt(), "nt", workspacedir);
     }
     
     /**
@@ -303,24 +304,36 @@ public class AsqatasunRunnerBuilder extends Builder {
     }
     
     private void setBuildStatus(AbstractBuild build, AsqatasunRunner asqatasunRunner) {
-        if ((StringUtils.isBlank(minMarkThresholdForStable) || Integer.valueOf(minMarkThresholdForStable)<0) &&
-                (StringUtils.isBlank(maxFailedOccurencesForStable) || Integer.valueOf(maxFailedOccurencesForStable)<0)) {
+        if (setBuildStatusFirstIfCondition()) {
             build.setResult(Result.SUCCESS);
             return;
         }
-        if (Integer.valueOf(minMarkThresholdForStable) > 0 &&
-                Float.valueOf(asqatasunRunner.mark) < Integer.valueOf(minMarkThresholdForStable) ) {
+        if (setBuildStatusSecondIfCondition(asqatasunRunner)) {
             build.setResult(Result.UNSTABLE);
             return;
         }
-        if (Integer.valueOf(maxFailedOccurencesForStable) > 0 && 
-                Integer.valueOf(asqatasunRunner.nbFailedOccurences) > Integer.valueOf(maxFailedOccurencesForStable)) {
+        if (setBuildStatusThirdIfCondition(asqatasunRunner)) {
             build.setResult(Result.UNSTABLE);
             return;
         }
         build.setResult(Result.SUCCESS);
     }
-    
+
+    private boolean setBuildStatusFirstIfCondition() {
+        return (StringUtils.isBlank(minMarkThresholdForStable) || Integer.valueOf(minMarkThresholdForStable)<0) &&
+               (StringUtils.isBlank(maxFailedOccurencesForStable) || Integer.valueOf(maxFailedOccurencesForStable)<0);
+    }
+
+    private boolean setBuildStatusSecondIfCondition(AsqatasunRunner asqatasunRunner) {
+        return Integer.valueOf(minMarkThresholdForStable) > 0 &&
+               Float.valueOf(asqatasunRunner.getMark()) < Integer.valueOf(minMarkThresholdForStable);
+    }
+
+    private boolean setBuildStatusThirdIfCondition(AsqatasunRunner asqatasunRunner) {
+        return Integer.valueOf(maxFailedOccurencesForStable) > 0 &&
+               Integer.valueOf(asqatasunRunner.getNbFailedOccurences()) > Integer.valueOf(maxFailedOccurencesForStable);
+    }
+
     /**
      * Create a temporary file within a temporary folder, created in the
      * contextDir if not exists (first time)
@@ -375,6 +388,7 @@ public class AsqatasunRunnerBuilder extends Builder {
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
+        public static final String PLEASE_FILL_IN_A_VALID_SCENARIO = "Please fill-in a valid scenario";
         private String pathToRunner = "";
         private String displayPort = "";
         private String firefoxPath = "";
@@ -411,11 +425,11 @@ public class AsqatasunRunnerBuilder extends Builder {
             try {
               IO.read(AsqatasunRunnerBuilder.forceVersion1ToScenario(value));
             } catch (IOException ex) {
-                return FormValidation.error("Please fill-in a valid scenario");
+                return FormValidation.error(PLEASE_FILL_IN_A_VALID_SCENARIO);
             } catch (ScriptFactory.SuiteException ex) {
-                return FormValidation.error("Please fill-in a valid scenario");
+                return FormValidation.error(PLEASE_FILL_IN_A_VALID_SCENARIO);
             } catch (org.json.JSONException ex) {
-                return FormValidation.error("Please fill-in a valid scenario");
+                return FormValidation.error(PLEASE_FILL_IN_A_VALID_SCENARIO);
             }
             return FormValidation.ok();
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1192 - String literals should not be duplicated.
squid:MethodCyclomaticComplexity - Methods should not be too complex.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
Please let me know if you have any questions.
George Kankava
